### PR TITLE
fix: correct installation guide and add repository metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">Ef-Themes for VSCode Fixed 🎨🛠️</h1>
 
 <p align="center">
-  <img src="https://img.shields.io/github/license/eziotamburini/ef-themes-vscode-fixed" alt="License">
+  <img src="https://img.shields.io/github/license/eztamb/ef-themes-vscode-fixed" alt="License">
 </p>
 
 Welcome to a refined and polished collection of Emacs-inspired themes, carefully adapted for Visual Studio Code. This repository contains a fixed, curated version of the [ef-themes-vscode](https://github.com/anhsirk0/ef-themes-vscode) collection. ✨
@@ -16,15 +16,25 @@ All original themes are credited to [anhsirk0](https://github.com/anhsirk0) and 
 
 Follow these simple steps to install:
 
+For standard VSCode users:
+
 ```bash
-git clone https://github.com/eziotamburini/ef-themes-vscode-fixed.git ~/.vscode/extensions/ef-themes
+git clone https://github.com/eztamb/ef-themes-vscode-fixed.git ~/.vscode/extensions/eztamb.ef-themes-fixed-1.0.0
+```
+
+**Note:** If the extension doesn't appear after installation, remove the extensions manifest and reload VS Code:
+
+```bash
+rm ~/.vscode/extensions/extensions.json
 ```
 
 For OSS or VSCodium users:
 
 ```bash
-git clone https://github.com/eziotamburini/ef-themes-vscode-fixed.git ~/.vscode-oss/extensions/ef-themes
+git clone https://github.com/eztamb/ef-themes-vscode-fixed.git ~/.vscode-oss/extensions/eztamb.ef-themes-fixed-1.0.0
 ```
+
+### Troubleshooting
 
 Then restart VSCode and enjoy! 🎉 Open the command palette (`Ctrl+Shift+P` or `Cmd+Shift+P`) and search for **"Color Theme"** to try out the new look. 🌈💻
 
@@ -33,13 +43,12 @@ Then restart VSCode and enjoy! 🎉 Open the command palette (`Ctrl+Shift+P` or 
 Here’s a taste of what’s included:
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/eziotamburini/ef-themes-vscode-fixed/screenshots/screenshots/ef-autumn.png" width="30%" alt="Ef-Autumn" />
-  <img src="https://raw.githubusercontent.com/eziotamburini/ef-themes-vscode-fixed/screenshots/screenshots/ef-maris-dark.png" width="30%" alt="Ef-Maris Dark" />
-  <img src="https://raw.githubusercontent.com/eziotamburini/ef-themes-vscode-fixed/screenshots/screenshots/ef-duo-light.png" width="30%" alt="Ef-Duo Light" />
+  <img src="https://raw.githubusercontent.com/eztamb/ef-themes-vscode-fixed/screenshots/screenshots/ef-autumn.png" width="30%" alt="Ef-Autumn" />
+  <img src="https://raw.githubusercontent.com/eztamb/ef-themes-vscode-fixed/screenshots/screenshots/ef-maris-dark.png" width="30%" alt="Ef-Maris Dark" />
+  <img src="https://raw.githubusercontent.com/eztamb/ef-themes-vscode-fixed/screenshots/screenshots/ef-duo-light.png" width="30%" alt="Ef-Duo Light" />
 </p>
 
-
-👉 View all the previews [in the `screenshots` branch](https://github.com/eziotamburini/ef-themes-vscode-fixed/tree/screenshots).
+👉 View all the previews [in the `screenshots` branch](https://github.com/eztamb/ef-themes-vscode-fixed/tree/screenshots).
 
 🎨 You can also [Visit the official Ef-Themes gallery »](https://protesilaos.com/emacs/ef-themes-pictures/)
 .

--- a/package.json
+++ b/package.json
@@ -1,10 +1,14 @@
 {
 	"name": "ef-themes-fixed",
 	"displayName": "Ef-Themes for VSCode Fixed",
-	"publisher": "eziotamburini",
+	"publisher": "eztamb",
 	"icon": "icon.png",
 	"version": "1.0.0" ,
     "license": "GPL-3.0-or-later",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/eztamb/ef-themes-vscode-fixed.git"
+	},
 	"engines": {
 		"vscode": "^1.12.0"
 	},


### PR DESCRIPTION
# Fix installation guide and extension detection

This PR Fixes Issue #1.

## Problem
Extension not detected when cloned directly into `~/.vscode/extensions`. Installation guide didn't follow VS Code's naming convention.

## Solution
- Updated installation instructions with correct folder naming: `publisher.name-version`
- Added troubleshooting section for extension detection issues
- Added repository metadata to package.json

## Changes
- Updated README with proper installation commands for VS Code and VSCodium
- Added extra step to clear extensions manifest if needed
- Added repository field to package.json
- Updated my username across both files